### PR TITLE
Added support for raspbian 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ips/
+words

--- a/bootsy.sh
+++ b/bootsy.sh
@@ -248,7 +248,12 @@ function bootsy_download () {
 	info $rspounder
 
 	logger "Installing Go"
-	/usr/bin/apt-get install -y golang-go=2:1.7~5 || respounder_error="TRUE"
+        if [ "$release" == "10" ];
+        then
+	    /usr/bin/apt-get install -y golang-go=2:1.11~1 || respounder_error="TRUE"
+        else
+	    /usr/bin/apt-get install -y golang-go=2:1.7~5 || respounder_error="TRUE"
+        fi
 	info $rspounder_go
 
 	logger "Building respounder"


### PR DESCRIPTION
The raspberry pi foundation recently released raspbian 10 and, from what I could find, no longer has downloads for raspbian 9 available on their website. This had originally broke the bootsy installer because the specified `golang-go` package version was not in the package repos. The solution to fix this was to add an if statement to check if the user was running the installer on raspbian 10 and if so to then install the newer version of golang. I also added a `.gitignore` file so `words` and `ips/` don't have to be manually deleted before every commit.